### PR TITLE
Check property name variations

### DIFF
--- a/library/src/main/java/me/paulschwarz/springdotenv/DotenvPropertyLoader.java
+++ b/library/src/main/java/me/paulschwarz/springdotenv/DotenvPropertyLoader.java
@@ -32,4 +32,8 @@ public class DotenvPropertyLoader {
   public Object getValue(String key) {
     return dotenv.get(key);
   }
+
+  boolean containsProperty(String key) {
+    return getValue(key) != null;
+  }
 }

--- a/library/src/test/java/me/paulschwarz/springdotenv/DotenvPropertySourceTest.java
+++ b/library/src/test/java/me/paulschwarz/springdotenv/DotenvPropertySourceTest.java
@@ -40,4 +40,19 @@ class DotenvPropertySourceTest {
   void valueFromEnvironmentOverride() {
     assertThat(source.getProperty("EXAMPLE_MESSAGE_3")).isEqualTo("Message 3 from system environment");
   }
+
+  @Test
+  void valueFromEnvironmentAsLowerCaseWithDots() {
+    assertThat(source.getProperty("example.message.2")).isEqualTo("Message 2 from system environment");
+  }
+
+  @Test
+  void valueFromEnvironmentAsLowerCaseWithDashes() {
+    assertThat(source.getProperty("example-message-2")).isEqualTo("Message 2 from system environment");
+  }
+
+  @Test
+  void valueFromEnvironmentAsLowerCaseWithDotsAndDashes() {
+    assertThat(source.getProperty("example.message-2")).isEqualTo("Message 2 from system environment");
+  }
 }


### PR DESCRIPTION
Apply relaxed binding as spring boot implementations

As discussed in the issue, the implementation supports more than only the documented pattern:
1. initial property name e.g. ``this.is-a_PROPERTY``
2. initial property name, replacing dots ``.`` by underscores ``_``,  e.g. ``this_is-a_PROPERTY``
3. initial property name, replacing hyphens ``-`` by underscores ``_``,  e.g. ``this.is_a_PROPERTY``
4. initial property name, replacing dots ``.`` **and** hyphens ``-`` by underscores ``_``,  e.g. ``this_is_a_PROPERTY``
5. uppercase property name,  e.g. ``THIS.IS-A_PROPERTY``
6. uppercase property name, replacing dots ``.`` by underscores ``_``,  e.g. ``THIS_IS-A_PROPERTY``
7. uppercase property name, replacing hyphens ``-`` by underscores ``_``,  e.g. ``THIS.IS_A_PROPERTY``
8. uppercase property name, replacing dots ``.`` **and** hyphens ``-`` by underscores ``_``,  e.g. ``THIS_IS_A_PROPERTY``

The tests focus on validating the documented pattern: if the code requires a property named ``this.is-a-property`` (or other combination of dots and hyphens), then providing ``THIS_IS_1_PROPERTY`` in dotenv file works.

close #16 