### PR TITLE
Continue support for legacy/deprecated systemProperties with warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   Update application properties, environment variables, and any scripts or
   documentation that control exporting dotenv values into system properties.
 
+  `systemProperties` is deprecated but still supported with warning.
+
 #### Artifact split & coordinates
 
 The project is now published as multiple artifacts. Consumers must choose the

--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ All configuration is optional. Defaults are sensible.
   Defaults to `true`. Set to `false` to completely disable integration.
 
 - `springdotenv.exportToSystemProperties`  
-  If enabled, variables loaded from `.env` are also exported to `System.getProperties()`.
+  If enabled, variables loaded from `.env` are also exported to `System.getProperties()`.  
+  This field was previously known as `systemProperties` but was renamed for clarity. 
+  It is deprecated but still supported with warning.
 
 - `springdotenv.ignoreIfMissing`  
   Defaults to `true`. Set to `false` to fail fast when `.env` is absent.

--- a/spring-dotenv/src/main/java/me/paulschwarz/springdotenv/DotenvConfig.java
+++ b/spring-dotenv/src/main/java/me/paulschwarz/springdotenv/DotenvConfig.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 public record DotenvConfig(
     boolean enabled,
@@ -14,6 +16,8 @@ public record DotenvConfig(
     boolean ignoreIfMissing,
     boolean exportToSystemProperties
 ) {
+
+    private static final Log log = LogFactory.getLog(DotenvConfig.class);
 
     // Defaults
     public static final String DEFAULT_DIRECTORY = null;
@@ -25,20 +29,26 @@ public record DotenvConfig(
 
     // Keys
     private static final String PREFIX = "springdotenv.";
+    private static final String K_ENABLED = PREFIX + "enabled";
     private static final String K_DIRECTORY = PREFIX + "directory";
     private static final String K_FILENAME = PREFIX + "filename";
     private static final String K_IGNORE_IF_MALFORMED = PREFIX + "ignoreIfMalformed";
     private static final String K_IGNORE_IF_MISSING = PREFIX + "ignoreIfMissing";
     private static final String K_EXPORT_TO_SYSTEM_PROPERTIES = PREFIX + "exportToSystemProperties";
-    private static final String K_ENABLED = PREFIX + "enabled";
+
+    // Legacy (deprecated) key
+    private static final String K_SYSTEM_PROPERTIES_LEGACY = PREFIX + "systemProperties";
 
     public static final List<String> ALL_KEYS = List.of(
+        K_ENABLED,
         K_DIRECTORY,
         K_FILENAME,
         K_IGNORE_IF_MALFORMED,
         K_IGNORE_IF_MISSING,
         K_EXPORT_TO_SYSTEM_PROPERTIES,
-        K_ENABLED
+
+        // Legacy (deprecated) key
+        K_SYSTEM_PROPERTIES_LEGACY
     );
 
     /**
@@ -52,13 +62,31 @@ public record DotenvConfig(
      * Test-friendly entry point
      */
     public static DotenvConfig load(Map<String, String> config) {
+        // Presence triggers warning (even if overridden by the new key)
+        boolean legacyPresent = config.containsKey(K_SYSTEM_PROPERTIES_LEGACY);
+        boolean newPresent = config.containsKey(K_EXPORT_TO_SYSTEM_PROPERTIES);
+
+        if (legacyPresent) {
+            log.warn("Configuration key '" + K_SYSTEM_PROPERTIES_LEGACY
+                + "' is deprecated and will be removed in a future release. "
+                + "Please use '" + K_EXPORT_TO_SYSTEM_PROPERTIES + "' instead. "
+                + "If both are set, '" + K_EXPORT_TO_SYSTEM_PROPERTIES + "' takes precedence.");
+        }
+
+        // Precedence: new wins, else legacy, else default
+        boolean exportToSystemProperties = newPresent
+            ? getBoolean(config, K_EXPORT_TO_SYSTEM_PROPERTIES, DEFAULT_EXPORT_TO_SYSTEM_PROPERTIES)
+            : (legacyPresent
+                ? getBoolean(config, K_SYSTEM_PROPERTIES_LEGACY, DEFAULT_EXPORT_TO_SYSTEM_PROPERTIES)
+                : DEFAULT_EXPORT_TO_SYSTEM_PROPERTIES);
+
         return new DotenvConfig(
             getBoolean(config, K_ENABLED, DEFAULT_ENABLED),
             getString(config, K_DIRECTORY, DEFAULT_DIRECTORY),
             getString(config, K_FILENAME, DEFAULT_FILENAME),
             getBoolean(config, K_IGNORE_IF_MALFORMED, DEFAULT_IGNORE_IF_MALFORMED),
             getBoolean(config, K_IGNORE_IF_MISSING, DEFAULT_IGNORE_IF_MISSING),
-            getBoolean(config, K_EXPORT_TO_SYSTEM_PROPERTIES, DEFAULT_EXPORT_TO_SYSTEM_PROPERTIES)
+            exportToSystemProperties
         );
     }
 

--- a/spring-dotenv/src/test/java/me/paulschwarz/springdotenv/DotenvConfigSystemFallbackTest.java
+++ b/spring-dotenv/src/test/java/me/paulschwarz/springdotenv/DotenvConfigSystemFallbackTest.java
@@ -16,7 +16,7 @@ class DotenvConfigSystemFallbackTest {
 
     @Test
     void verifyDotenvConfigOptions() {
-        assertThat(DotenvConfig.ALL_KEYS).hasSize(6);
+        assertThat(DotenvConfig.ALL_KEYS).hasSize(7);
     }
 
     @Test
@@ -36,6 +36,33 @@ class DotenvConfigSystemFallbackTest {
         assertThat(cfg.filename()).isEqualTo("smoke.env");
         assertThat(cfg.ignoreIfMissing()).isFalse();
         assertThat(cfg.ignoreIfMalformed()).isTrue();
+        assertThat(cfg.exportToSystemProperties()).isTrue();
+    }
+
+    /**
+     * Legacy support: remove when we no longer support systemProperties
+     */
+    @Test
+    void legacy__systemProperties() {
+        sys.set("springdotenv.systemProperties", "true");
+
+        // Read in the sysprops/env/defaults
+        DotenvConfig cfg = DotenvConfig.load();
+
+        assertThat(cfg.exportToSystemProperties()).isTrue();
+    }
+
+    /**
+     * Legacy support: remove when we no longer support systemProperties
+     */
+    @Test
+    void legacy__exportToSystemProperties_beats_systemProperties() {
+        sys.set("springdotenv.exportToSystemProperties", "true");
+        sys.set("springdotenv.systemProperties", "false");
+
+        // Read in the sysprops/env/defaults
+        DotenvConfig cfg = DotenvConfig.load();
+
         assertThat(cfg.exportToSystemProperties()).isTrue();
     }
 }

--- a/spring-dotenv/src/test/java/me/paulschwarz/springdotenv/DotenvConfigTest.java
+++ b/spring-dotenv/src/test/java/me/paulschwarz/springdotenv/DotenvConfigTest.java
@@ -11,7 +11,7 @@ class DotenvConfigTest {
 
     @Test
     void verifyDotenvConfigOptions() {
-        Assertions.assertThat(DotenvConfig.ALL_KEYS).hasSize(6);
+        Assertions.assertThat(DotenvConfig.ALL_KEYS).hasSize(7);
     }
 
     @Test


### PR DESCRIPTION
The new `DotenvConfig.load` only reads `springdotenv.exportToSystemProperties`, so existing configurations that still set the previously documented `springdotenv.systemProperties` (or `SPRINGDOTENV_SYSTEM_PROPERTIES`) now default to `false` and stop exporting dotenv values to system properties. This silently breaks deployments relying on the old flag without any migration path or deprecation layer.